### PR TITLE
Bring EIP-2535 up to current EIP requirements

### DIFF
--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -1,6 +1,7 @@
 ---
 eip: 2535
 title: Diamonds
+description: Enables people to write smart contracts with virtually no size limit in a modular and gas-efficient way.
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
 status: Draft
@@ -11,17 +12,9 @@ created: 2020-02-22
 
 <img align="right" src="../assets/eip-2535/diamond.svg" width="230" height="230">
 
-## Simple Summary
+## Abstract
 
-Enables people to write smart contracts with virtually no size limit in a modular and gas-efficient way.
-
-Diamonds can be upgraded on the fly without having to redeploy existing functionality.
-
-Standardizes contract interfaces and implementation details of diamonds, enabling software integration and interoperability.
-
-A diamond is a contract that implements the Specification in this standard.
-
-Terminology from the diamond industry.
+This EIP standardizes contract interfaces for Diamonds, which are modular smart contracts with a simple yet customizable upradeability mechanism. It also provdies suggested introspection methods, enabling software integration and interoperability. The terminology in this EIP is derived from and analoogous to the terminology of the diamond industry.
 
 ## Motivation
 
@@ -52,9 +45,7 @@ The loupe functions can be used for many things including:
 
 Diamonds support another form of transparency which is a historical record of all upgrades on a diamond. This is done with the DiamondCut event which is used to record all functions that are added, replaced or removed on a diamond. 
 
-This standard is an improvement of [EIP-1538 Transparent Contract Standard](https://eips.ethereum.org/EIPS/eip-1538). The same motivations of that standard apply to this standard.
-
-See the [Learning & References section](https://eips.ethereum.org/EIPS/eip-2535#learning--references) for additional information and uses of diamonds.
+This standard is an improvement of [EIP-1538](./eip-1538.md). The same motivations of that standard apply to this standard.
 
 ## What is a Diamond?
 
@@ -186,9 +177,6 @@ contract StakingFacet {
 ```
 
 The above example accesses the `s.firstVar` state variable and stores a computation in the `s.total` state variable.
-
-Read this article to learn more about AppStorage: [AppStorage Pattern for State Variables in Solidity](https://dev.to/mudgen/appstorage-pattern-for-state-variables-in-solidity-3lki).
-
 
 ## Diamonds Can Use Other Contract Storage Strategies
 
@@ -459,8 +447,6 @@ interface IDiamondLoupe {
 }
 ```
 
-See an [example implementation](https://github.com/mudgen/Diamond) to see how this can be implemented.
-
 The loupe functions can be used in user-interface software. A user interface calls these functions to provide information about and visualize diamonds.
 
 The loupe functions can be used in deployment functionality, upgrade functionality, testing and other software.
@@ -477,13 +463,9 @@ A diamond implements the following implementation points:
 1. Each time functions are added, replaced or removed a `DiamondCut` event is emitted to record it.
 1. A diamond implements the DiamondLoupe interface.
 1. All immutable functions must be emitted in the `DiamondCut` event as new functions added. And the loupe functions must return information about immutable functions if they exist. The facet address for an immutable function is the diamond's address.
-1. Optionally a diamond implements ERC165. If a diamond has the `diamondCut` function then the interface ID used for it is `IDiamondCut.diamondCut.selector`. The interface ID used for the diamond loupe interface is `IDiamondLoupe.facets.selector ^ IDiamondLoupe.facetFunctionSelectors.selector ^ IDiamondLoupe.facetAddresses.selector ^ IDiamondLoupe.facetAddress.selector`.
+1. Optionally a diamond implements EIP-165. If a diamond has the `diamondCut` function then the interface ID used for it is `IDiamondCut.diamondCut.selector`. The interface ID used for the diamond loupe interface is `IDiamondLoupe.facets.selector ^ IDiamondLoupe.facetFunctionSelectors.selector ^ IDiamondLoupe.facetAddresses.selector ^ IDiamondLoupe.facetAddress.selector`.
 
 The diamond address is the address that users interact with. The diamond address does not change. Only facet addresses can change by using the `diamondCut` function, or other function.
-
-## Implementation
-
-Example diamond implementations exist in the [Diamond repository](https://github.com/mudgen/Diamond).
 
 ## Rationale
 
@@ -497,14 +479,14 @@ This standard is designed to make diamonds work well with user-interface softwar
 
 Delegating function calls does have some gas overhead. This is mitigated in several ways:
 
-1. Because diamonds do not have a max size limitation it is possible to add gas optimizing functions for use cases. For example someone could use a diamond to implement the ERC721 standard and implement batch transfer functions from the [ERC1412 standard](https://github.com/ethereum/EIPs/issues/1412) to reduce gas (and make batch transfers more convenient).
+1. Because diamonds do not have a max size limitation it is possible to add gas optimizing functions for use cases. For example someone could use a diamond to implement the EIP-721 standard and implement batch transfer functions from another standard to reduce gas (and make batch transfers more convenient).
 1. Some contract architectures require calling many contracts in one transaction. Gas savings can be realized by condensing those contracts into a single diamond and accessing contract storage directly.
 1. Facets can be small, reducing gas costs. Because it costs more gas to call a function in a contract with many functions than a contract with few functions.
 1. The Solidity optimizer can be set to a high setting causing more bytecode to be generated but the facets will use less gas when executed.
 
 ### Diamond Storage
 
-Since Solidity 0.6.4 it is possible to create pointers to structs in arbitrary places in contract storage. This enables diamonds and their facets to create their own storage layouts that are separate from each other and do not conflict with each other, but can still be shared between them. See this blog post for more information: [New Storage Layout For Proxy Contracts and Diamonds](https://medium.com/1milliondevs/new-storage-layout-for-proxy-contracts-and-diamonds-98d01d0eadb). The example implementation for EIP-2535 uses diamond storage.
+Since Solidity 0.6.4 it is possible to create pointers to structs in arbitrary places in contract storage. This enables diamonds and their facets to create their own storage layouts that are separate from each other and do not conflict with each other, but can still be shared between them. The example implementation for this EIP uses diamond storage.
 
 Diamond storage is not the same thing as unstructured storage. Unstructured storage reads and writes specific values like unsigned integers and addresses at specified locations in contract storage. Diamond storage uses structs at specified locations in contract storage for reading and writing. Structs can hold any number of state variables of any type.
 
@@ -521,17 +503,8 @@ Here are some solutions to this:
 1. Put common internal functions in a contract that is inherited by multiple facets.
 1. Put common internal functions in a Solidity library and use the library in facets.
 1. A type safe way to call an external function defined in another facet is to do this: MyOtherFacet(this).myFunction(arg1, arg2) 
-1. A more gas-efficient way to call an external function defined in another facet is to use `delegatecall`. Here is an example of doing that:
-```Solidity
-DiamondStorage storage ds = diamondStorage();
-bytes4 functionSelector = bytes4(keccak256("myFunction(uint256)"));
-// get facet address of function
-address facet = ds.selectorToFacet[functionSelector];
-bytes memory myFunctionCall = abi.encodeWithSelector(functionSelector, 4);
-(bool success, uint result) = address(facet).delegatecall(myFunctionCall);
-require(success, "myFunction failed");
-```
-6. Instead of calling an external function defined in another facet you can instead create an internal function version of the external function. Add the internal version of the function to the facet that needs to use it.
+1. A more gas-efficient way to call an external function defined in another facet is to use `delegatecall`.
+1. Instead of calling an external function defined in another facet you can instead create an internal function version of the external function. Add the internal version of the function to the facet that needs to use it.
 
 ## Security Considerations
 
@@ -539,7 +512,7 @@ require(success, "myFunction failed");
 
 > **Note:** The design and implementation of diamond ownership/authentication is **not** part of this standard. The examples given in this standard and in the reference implementation are just **examples** of how it could be done.
 
-It is possible to create many different authentication or ownership schemes with EIP-2535. Authentication schemes can be very simple or complex, fine grained or coarse. EIP-2535 does not limit it in any way. For example ownership/authentication could be as simple as a single account address having the authority to add/replace/remove functions. Or a decentralized autonomous organization could have the authority to only add/replace/remove certain functions.
+It is possible to create many different authentication or ownership schemes with this EIP. Authentication schemes can be very simple or complex, fine grained or coarse. This EIP does not limit it in any way. For example ownership/authentication could be as simple as a single account address having the authority to add/replace/remove functions. Or a decentralized autonomous organization could have the authority to only add/replace/remove certain functions.
 
 Consensus functionality could be implemented such as an approval function that multiple different people call to approve changes before they are executed with the `diamondCut` function. These are just examples.
 
@@ -586,74 +559,6 @@ Security and domain experts can review the history of change of a diamond to det
 
 This standard makes upgradeable diamonds compatible with future standards and functionality because new functions can be added and existing functions can be replaced or removed.
 
-## Learning & References
-
-### Diamond Articles
-
-[Why Ethereum Diamonds Need A Standard](https://dev.to/mudgen/why-diamonds-need-a-standard-1i1h)
-
-[Ethereum's Maximum Contract Size Limit is Solved with EIP-2535 Diamonds](https://dev.to/mudgen/ethereum-s-maximum-contract-size-limit-is-solved-with-the-diamond-standard-2189)
-
-[Understanding Diamonds](https://dev.to/mudgen/understanding-diamonds-on-ethereum-1fb)
-
-[Why Ethereum Diamonds Need A Standard](https://dev.to/mudgen/why-diamonds-need-a-standard-1i1h)
-
-[Diamond Loupe Functions?](https://dev.to/mudgen/why-loupe-functions-for-diamonds-1kc3)
-
-[EIP-2535 Diamonds: A new paradigm for upgradeability](https://medium.com/derivadex/the-diamond-standard-a-new-paradigm-for-upgradeability-569121a08954)
-
-[Upgradeable smart contracts using EIP-2535 Diamonds](https://hiddentao.com/archives/2020/05/28/upgradeable-smart-contracts-using-diamond-standard)
-
-[Ethereum Diamonds for On-Chain Decentralized Governance](https://dev.to/mudgen/ethereum-diamonds-for-on-chain-decentralized-governance-39op)
-
-[How to Share Functions Between Facets of a Diamond](https://dev.to/mudgen/how-to-share-functions-between-facets-of-a-diamond-1njb)
-
-### Diamond Storage Articles
-
-[How Diamond Storage Works](https://dev.to/mudgen/how-diamond-storage-works-90e)
-
-[AppStorage Pattern for State Variables in Solidity](https://dev.to/mudgen/appstorage-pattern-for-state-variables-in-solidity-3lki)
-
-[New Storage Layout For Proxy Contracts and Diamonds](https://medium.com/1milliondevs/new-storage-layout-for-proxy-contracts-and-diamonds-98d01d0eadb)
-
-[Solidity Libraries Can't Have State Variables -- Oh Yes They Can!](https://dev.to/mudgen/solidity-libraries-can-t-have-state-variables-oh-yes-they-can-3ke9)
-
-[ Smart Contracts Sharing Common Data](https://medium.com/coinmonks/smart-contracts-sharing-common-data-777310263ac0?source=friends_link&sk=b462ff3559ae9c8da243ba31a557e4f4)
-
-[Sharing Common Data Using Libraries](https://medium.com/coinmonks/sharing-common-data-using-libraries-6573857d328c?source=friends_link&sk=1da1ef153b8d15f3f7bb9f4ce429890a)
-
-### Diamond Tools
-
-[Louper](https://louper.dev/) A user interface for all diamonds.
-
-[buidler-deploy](https://github.com/wighawag/buidler-deploy#diamonds-and-facets)
-
-### Implementations
-
-[Diamond example implementations](https://github.com/mudgen/Diamond)
-
-[GHST Staking](https://github.com/aavegotchi/ghst-staking)
-
-[pie-dao / ExperiPie](https://github.com/pie-dao/ExperiPie)
-
-[Nayms Contracts](https://github.com/nayms/contracts)
-
-[Aavegotchi Diamond](https://github.com/aavegotchi/aavegotchi-contracts)
-
-### Help
-
-[EIP-2535 Diamonds Discord](https://discord.gg/kQewPw2)
-
-## Inspiration & Development
-
-EIP-2535 is an improved design over [EIP-1538](./eip-1538.md) using ABIEncoderV2 and function selectors.
-
-EIP-2535 replaces EIP-1538.
-
-This standard was inspired by [EIP-1538](./eip-1538.md) and ZeppelinOS's implementation of [Upgradeability with vtables](https://github.com/zeppelinos/labs/tree/master/upgradeability_with_vtable). 
-
-This standard was also inspired by the design and implementation of the [Mokens contract](https://etherscan.io/address/0xc1eab49cf9d2e23e43bcf23b36b2be14fc2f8838#code).
-
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This does not make any changes to the spec. This is the minimum amount of changes needed to get this to a valid EIP.

This does delete the reference implementation section. Feel free to add it back later, but in the interest of moving this forward, it has been removed.

Reminder: Smaller is *better*. Your current reference implementation is probably too complete.